### PR TITLE
Update node_modules regex check

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = (nextConfig = {}) => {
       // Replace /node_modules/ by the new exclude RegExp (including the modules
       // that are going to be transpiled)
       const ignored = config.watchOptions.ignored.filter(
-        regexp => !regexEqual(regexp, /node_modules/)
+        regexp => !regexEqual(regexp, /[\\\/]node_modules[\\\/]/)
       ).concat(excludes);
 
       config.watchOptions.ignored = ignored;


### PR DESCRIPTION
All node modules are currently ignored during watch, because the regexp doesn't match the current one in Next.

https://github.com/zeit/next.js/blob/815f2e91386a0cd046c63cbec06e4666cff85971/packages/next/server/hot-reloader.js#L335